### PR TITLE
Default to a non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM python:3.8-slim
 RUN pip install --no-cache notebook jupyterlab
-ENV HOME=/tmp
+RUN useradd -m test
+USER test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM python:3.8-slim
 RUN pip install --no-cache notebook jupyterlab
-RUN useradd -m test
-USER test
+RUN useradd -m jovyan
+USER jovyan


### PR DESCRIPTION
Otherwise jupyter complains about being run as root. This is needed when using spawners other than KubeSpawner which do not override the default container user.