### PR TITLE
Add JupyterHub (needed for testing auth), Python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
-RUN pip install --no-cache notebook jupyterlab
+FROM python:3.12-slim
+RUN pip install --no-cache notebook jupyterlab jupyterhub
 RUN useradd -m jovyan
 USER jovyan


### PR DESCRIPTION
This provides a quick way for new deployments of authenticated BinderHubs to check they're working.