### PR TITLE
Add workdir, update to Python 3.14, fix readme badge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.14-slim
 RUN pip install --no-cache notebook jupyterlab jupyterhub
 RUN useradd -m jovyan
 USER jovyan

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,3 +2,4 @@ FROM python:3.12-slim
 RUN pip install --no-cache notebook jupyterlab jupyterhub
 RUN useradd -m jovyan
 USER jovyan
+WORKDIR /home/jovyan

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # About
 
-[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/binderhub-ci-repos/minimal-dockerfile/Build%20and%20push?logo=github&label=Build%20and%20push%20cron%20job)](https://github.com/binderhub-ci-repos/minimal-dockerfile/actions)
+[![GitHub Workflow Status](https://github.com/binderhub-ci-repos/minimal-dockerfile/actions/workflows/build-and-push-cron.yaml/badge.svg)](https://github.com/binderhub-ci-repos/minimal-dockerfile/actions/workflows/build-and-push-cron.yaml)
 
 This repository is built and published every night to
 [DockerHub](https://hub.docker.com/repository/docker/jupyterhub/binderhub-ci-repos_minimal-dockerfile)


### PR DESCRIPTION
The image currently launches Jupyter-server/JupyterLab in the root directory, which isn't writeable.